### PR TITLE
Export typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Export Typescript typings.
 
 ## [0.0.2] - 2020-10-14
 ### Added


### PR DESCRIPTION
This is a dummy PR just to generate a new release, triggering the updated builder-hub (which wasn't exporting graphql types before). See https://github.com/vtex/builder-hub/pull/1065 for a more detailed explanation and testing suites.