### PR TITLE
CHK-468: Add getLogo query

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,19 @@
+name: PR actions
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  danger-ci:
+    name: Danger CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+      - name: Danger CI
+        uses: vtex/danger@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Query for provider logo retrieval.
 
 ## [0.0.4] - 2020-10-27
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -2,4 +2,6 @@ type Query {
   suggestAddresses(searchTerm: String!): [AddressSuggestion!]!
 
   getAddressByExternalId(id: String!): Address!
+
+  getLogo: Image!
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,5 +3,5 @@ type Query {
 
   getAddressByExternalId(id: String!): Address!
 
-  getLogo: Image!
+  providerLogo: Image!
 }

--- a/graphql/types/Image.graphql
+++ b/graphql/types/Image.graphql
@@ -1,0 +1,10 @@
+type File {
+  filename: String!
+  mimetype: String!
+  encoding: String!
+}
+
+type Image {
+  src: String!
+  alt: String!
+}

--- a/graphql/types/Image.graphql
+++ b/graphql/types/Image.graphql
@@ -1,9 +1,3 @@
-type File {
-  filename: String!
-  mimetype: String!
-  encoding: String!
-}
-
 type Image {
   src: String!
   alt: String!


### PR DESCRIPTION
#### What problem is this solving?

Adds a query that allows the retrieval of the provider logo URL.

#### How should this be manually tested?

- [Workspace](https://w0geo--checkoutio.myvtex.com/cart/add?sku=289)
- Go to shipping
- Start to type a valid address. You can use "Praia de b".
- Assert that the `powered by Google` logo is displayed on bottom right of the suggestion list

#### Screenshots or example usage

You should see this:

<img src="https://user-images.githubusercontent.com/26108090/100797919-a2732980-3401-11eb-9f10-f8be7d5c3635.png" width="450" />
