### PR TITLE
CHK-435: Session token

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,6 @@
 #### Checklist/Reminders
 
 - [ ] Linked this PR to a JIRA story (if applicable).
-- [ ] Updated/created tests.
 - [ ] Deleted the workspace after merging this PR (if applicable).
 
 #### Screenshots or example usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Query for session token retrieval.
+- Session token argument for search queries.
 
 ## [0.1.0] - 2020-12-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Query for session token retrieval.
 - Session token argument for search queries.
+### Changed
+- GetAddressByExternalId query is now Address.
+- SuggestAddresses query is now AddressSuggestions.
 
 ## [0.1.0] - 2020-12-04
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,11 @@ This app exports a GraphQL schema for geolocation results for Place Components.
 
 To use it in your app, run the `vtex add vtex.geolocation-graphql-interface` command.
 
-You may then use it in your front end component queries, for example, by writing the file `suggestAddresses.graphql`:
+You may then use it in your front end component queries, for example, by writing the file `addressSuggestions.graphql`:
 
 ```graphql
-query SuggestAddresses($searchTerm: String!) {
-  suggestAddresses(searchTerm: $searchTerm)
+query AddressSuggestions($searchTerm: String!) {
+  addressSuggestions(searchTerm: $searchTerm)
     @context(provider: "vtex.geolocation-graphql-interface") {
     description
     mainText
@@ -36,11 +36,11 @@ Having zero or more than one resolver installed will result in an error.
 
 ### Examples
 
-Currently, this interface only supports autosuggest related operations, which is commonly used along with a text-based input like the [Location Search component](https://github.com/vtex-apps/place-components/#locationfield-search) used in `vtex.place-components`. In order to get the suggestions, each key-stroke might send a `suggestAddresses` query like:
+Currently, this interface only supports autosuggest related operations, which is commonly used along with a text-based input like the [Location Search component](https://github.com/vtex-apps/place-components/#locationfield-search) used in `vtex.place-components`. In order to get the suggestions, each key-stroke might send a `addressSuggestions` query like:
 
 ```graphql
 query {
-  suggestAddresses(searchTerm: "Praia de bot") {
+  addressSuggestions(searchTerm: "Praia de bot") {
     description
     externalId
   }
@@ -52,7 +52,7 @@ This returns address suggestions using the resolver of your choice. Notice that 
 ```graphql
 {
   "data": {
-    "suggestAddresses": [
+    "addressSuggestions": [
       {
         "description": "Praia de Botafogo - Botafogo, Rio de Janeiro - RJ, Brasil",
         "externalId": "SAMPLE_ID_2718"
@@ -78,11 +78,11 @@ This returns address suggestions using the resolver of your choice. Notice that 
 }
 ```
 
-If the user selects the first suggested address, we must use it's `externalId` to make a `getAddressByExternalId` query:
+If the user selects the first suggested address, we must use it's `externalId` to make an `address` query:
 
 ```graphql
 query {
-  getAddressByExternalId(id: "SAMPLE_ID_2718") {
+  address(id: "SAMPLE_ID_2718") {
     city
     neighborhood
     street
@@ -95,7 +95,7 @@ Which returns an address object that can be used to autocomplete an address form
 ```graphql
 {
   "data": {
-    "getAddressByExternalId": {
+    "address": {
       "city": "Rio de Janeiro",
       "neighborhood": "Botafogo",
       "street": "Praia de Botafogo"

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,10 +1,10 @@
 type Query {
-  suggestAddresses(
+  addressSuggestions(
     searchTerm: String!
     sessionToken: String
   ): [AddressSuggestion!]!
 
-  getAddressByExternalId(id: String!, sessionToken: String): Address!
+  address(externalId: String!, sessionToken: String): Address!
 
   providerLogo: Image!
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,7 +1,10 @@
 type Query {
-  suggestAddresses(searchTerm: String!): [AddressSuggestion!]!
+  suggestAddresses(
+    searchTerm: String!
+    sessionToken: String
+  ): [AddressSuggestion!]!
 
-  getAddressByExternalId(id: String!): Address!
+  getAddressByExternalId(id: String!, sessionToken: String): Address!
 
   providerLogo: Image!
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -7,4 +7,6 @@ type Query {
   getAddressByExternalId(id: String!, sessionToken: String): Address!
 
   providerLogo: Image!
+
+  sessionToken: String!
 }


### PR DESCRIPTION
#### What problem is this solving?

Many geolocalization providers allows the use of a session token in order to keep track of a single "autocomplete usage session". This usually has the benefits of being billed only once, which can save us some costs. More info on the Jira task.

#### How should this be manually tested?

[Run this GraphQL query.](https://w0geo--checkoutio.myvtex.com/_v/private/vtex.geolocation-graphql-interface@0.1.0/graphiql/v1?query=%7B%0A%20%20sessionToken%0A%7D%0A)

Notice that each resolver chooses what and how their session token gonna be. For the above query, it will always return an UUID.

#### Checklist/Reminders

- [x] Linked this PR to a JIRA story (if applicable).
- [ ] Deleted the workspace after merging this PR (if applicable).